### PR TITLE
Add Lodestone transformer model with training pipeline

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+  "name": "lodestone",
+  "build": {
+    "dockerfile": "../Dockerfile"
+  },
+  "workspaceFolder": "/workspace/Lodestone",
+  "settings": {},
+  "extensions": [
+    "ms-python.python"
+  ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM dennisgoldfarb/pytorch_ris:lightning
+
+WORKDIR /workspace/Lodestone
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "-m", "lodestone.train", "--config", "config.json"]

--- a/config.json
+++ b/config.json
@@ -1,0 +1,10 @@
+{
+  "csv_path": "data/CSD_train.csv",
+  "batch_size": 32,
+  "lr": 0.001,
+  "d_model": 128,
+  "nhead": 4,
+  "num_layers": 2,
+  "run_dim": 32,
+  "max_epochs": 5
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+torch
+pytorch-lightning
+wandb
+matplotlib
+pandas
+numpy

--- a/slurm/train_lodestone.sh
+++ b/slurm/train_lodestone.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#BSUB -g /d.goldfarb/compute
+#BSUB -G compute-d.goldfarb
+#BSUB -a 'docker(dennisgoldfarb/pytorch_ris:lightning)'
+#BSUB -J lodestone-train
+#BSUB -q general
+#BSUB -R "gpuhost rusage[mem=40GB] span[hosts=1]"
+#BSUB -gpu 'num=1:gmem=6G:gmodel=NVIDIAA40'
+#BSUB -n 8
+#BSUB -W 1440
+#BSUB -M 40G
+#BSUB -o /scratch1/fs1/d.goldfarb/Lodestone/logs/train.%J.out.txt
+#BSUB -e /scratch1/fs1/d.goldfarb/Lodestone/logs/train.%J.err.txt
+
+REPO_DIR=/storage1/fs1/d.goldfarb/Active/Projects/Lodestone
+
+cd ${REPO_DIR}
+PYTHONPATH=src \
+    /bin/python3 -m lodestone.train --config config.json

--- a/src/lodestone/__init__.py
+++ b/src/lodestone/__init__.py
@@ -1,0 +1,3 @@
+"""Lodestone package."""
+
+__all__ = ["data", "model", "train"]

--- a/src/lodestone/data.py
+++ b/src/lodestone/data.py
@@ -1,0 +1,106 @@
+import math
+from dataclasses import dataclass
+from typing import List, Dict, Tuple
+
+import pandas as pd
+import torch
+from torch.utils.data import Dataset, DataLoader, random_split
+import pytorch_lightning as pl
+
+AMINO_ACIDS = list("ACDEFGHIKLMNPQRSTVWY")
+SPECIAL_TOKENS = ["camC", "oxM"]
+VOCAB = AMINO_ACIDS + SPECIAL_TOKENS
+TOKEN_TO_IDX: Dict[str, int] = {tok: i for i, tok in enumerate(VOCAB)}
+
+
+def tokenize_sequence(seq: str) -> List[int]:
+    tokens: List[int] = []
+    i = 0
+    while i < len(seq):
+        if seq.startswith("camC", i):
+            tokens.append(TOKEN_TO_IDX["camC"])
+            i += 4
+        elif seq.startswith("oxM", i):
+            tokens.append(TOKEN_TO_IDX["oxM"])
+            i += 3
+        else:
+            aa = seq[i]
+            if aa not in TOKEN_TO_IDX:
+                raise KeyError(f"Unknown token {aa} in sequence {seq}")
+            tokens.append(TOKEN_TO_IDX[aa])
+            i += 1
+    return tokens
+
+
+def one_hot(indices: List[int]) -> torch.Tensor:
+    eye = torch.eye(len(VOCAB))
+    return eye[indices]
+
+
+@dataclass
+class PeptideRecord:
+    sequence: str
+    charges: torch.Tensor
+    run_id: int
+
+
+class PeptideDataset(Dataset):
+    def __init__(self, df: pd.DataFrame, run_mapping: Dict[str, int]):
+        self.df = df
+        self.run_mapping = run_mapping
+
+    def __len__(self) -> int:
+        return len(self.df)
+
+    def __getitem__(self, idx: int) -> PeptideRecord:
+        row = self.df.iloc[idx]
+        seq = row[0]
+        charges = torch.tensor(row[1:6].values.astype(float), dtype=torch.float32)
+        run_id = self.run_mapping[row[6]]
+        return PeptideRecord(sequence=seq, charges=charges, run_id=run_id)
+
+
+class PeptideDataModule(pl.LightningDataModule):
+    def __init__(self, csv_path: str, batch_size: int = 32):
+        super().__init__()
+        self.csv_path = csv_path
+        self.batch_size = batch_size
+        self.run_mapping: Dict[str, int] = {}
+        self.train_set: Dataset | None = None
+        self.val_set: Dataset | None = None
+        self.test_set: Dataset | None = None
+
+    def prepare_data(self) -> None:
+        pass
+
+    def setup(self, stage: str | None = None) -> None:
+        df = pd.read_csv(self.csv_path)
+        run_names = sorted(df["dataset"].unique())
+        self.run_mapping = {name: i for i, name in enumerate(run_names)}
+
+        dataset = PeptideDataset(df, self.run_mapping)
+        n = len(dataset)
+        n_train = int(0.7 * n)
+        n_val = int(0.2 * n)
+        n_test = n - n_train - n_val
+        self.train_set, self.val_set, self.test_set = random_split(
+            dataset, [n_train, n_val, n_test], generator=torch.Generator().manual_seed(42)
+        )
+
+    def collate_fn(self, batch: List[PeptideRecord]) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        seqs = [tokenize_sequence(rec.sequence) for rec in batch]
+        max_len = max(len(s) for s in seqs)
+        padded = [s + [0] * (max_len - len(s)) for s in seqs]
+        one_hot_seqs = torch.stack([one_hot(s) for s in padded])
+        charges = torch.stack([rec.charges for rec in batch])
+        run_ids = torch.tensor([rec.run_id for rec in batch], dtype=torch.long)
+        return one_hot_seqs, charges, run_ids
+
+    def train_dataloader(self) -> DataLoader:
+        return DataLoader(self.train_set, batch_size=self.batch_size, shuffle=True, collate_fn=self.collate_fn)
+
+    def val_dataloader(self) -> DataLoader:
+        return DataLoader(self.val_set, batch_size=self.batch_size, shuffle=False, collate_fn=self.collate_fn)
+
+    def test_dataloader(self) -> DataLoader:
+        return DataLoader(self.test_set, batch_size=self.batch_size, shuffle=False, collate_fn=self.collate_fn)

--- a/src/lodestone/model.py
+++ b/src/lodestone/model.py
@@ -1,0 +1,107 @@
+from typing import Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import pytorch_lightning as pl
+
+from .data import VOCAB
+
+
+class PositionalEncoding(nn.Module):
+    def __init__(self, d_model: int, max_len: int = 5000):
+        super().__init__()
+        pe = torch.zeros(max_len, d_model)
+        position = torch.arange(0, max_len).unsqueeze(1).float()
+        div_term = torch.exp(torch.arange(0, d_model, 2).float() * (-torch.log(torch.tensor(10000.0)) / d_model))
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        pe = pe.unsqueeze(0)
+        self.register_buffer("pe", pe)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x + self.pe[:, : x.size(1)]
+        return x
+
+
+class LodestoneModel(nn.Module):
+    def __init__(self, d_model: int, nhead: int, num_layers: int, run_dim: int, num_runs: int, num_charge: int = 5):
+        super().__init__()
+        self.embed = nn.Linear(len(VOCAB), d_model)
+        self.pos_encoder = PositionalEncoding(d_model)
+        encoder_layer = nn.TransformerEncoderLayer(d_model=d_model, nhead=nhead, batch_first=True)
+        self.transformer = nn.TransformerEncoder(encoder_layer, num_layers=num_layers)
+        self.weight_head = nn.Linear(d_model, run_dim * num_charge)
+        self.run_params = nn.Embedding(num_runs, run_dim)
+        self.k_factors = nn.Embedding(num_runs, num_charge)
+
+    def forward(self, x: torch.Tensor, run_ids: torch.Tensor) -> torch.Tensor:
+        # x: [B, L, V]
+        x = self.embed(x)
+        x = self.pos_encoder(x)
+        x = self.transformer(x)
+        x = x.mean(dim=1)
+        weights = self.weight_head(x).view(x.size(0), -1, self.run_params.embedding_dim)
+        run_vec = self.run_params(run_ids).unsqueeze(-1)
+        preds = torch.bmm(weights, run_vec).squeeze(-1)
+        k = self.k_factors(run_ids)
+        preds = preds * k
+        return preds
+
+
+class LodestoneLightningModule(pl.LightningModule):
+    def __init__(self, num_runs: int, lr: float = 1e-3, d_model: int = 128, nhead: int = 4, num_layers: int = 2, run_dim: int = 32):
+        super().__init__()
+        self.save_hyperparameters()
+        self.model = LodestoneModel(
+            d_model=d_model,
+            nhead=nhead,
+            num_layers=num_layers,
+            run_dim=run_dim,
+            num_runs=num_runs,
+        )
+        self.val_examples = []
+
+    def forward(self, x: torch.Tensor, run_ids: torch.Tensor) -> torch.Tensor:
+        return self.model(x, run_ids)
+
+    def training_step(self, batch: Tuple[torch.Tensor, torch.Tensor, torch.Tensor], batch_idx: int):
+        x, y, run_ids = batch
+        preds = self(x, run_ids)
+        loss = F.mse_loss(torch.softmax(preds, dim=-1), y)
+        self.log("train_loss_epoch", loss, on_step=False, on_epoch=True, prog_bar=True)
+        if (self.global_step + 1) % 50 == 0:
+            self.log("train_loss", loss, on_step=True, on_epoch=False, prog_bar=True)
+        return loss
+
+    def validation_step(self, batch: Tuple[torch.Tensor, torch.Tensor, torch.Tensor], batch_idx: int):
+        x, y, run_ids = batch
+        preds = self(x, run_ids)
+        loss = F.mse_loss(torch.softmax(preds, dim=-1), y)
+        self.log("val_loss", loss, on_step=False, on_epoch=True, prog_bar=True)
+        if len(self.val_examples) < 10:
+            self.val_examples.append(
+                (y[0].detach(), torch.softmax(preds.detach(), dim=-1)[0])
+            )
+        return loss
+
+    def on_validation_epoch_end(self):
+        import matplotlib.pyplot as plt
+        import wandb
+
+        for y, p in self.val_examples:
+            if (y > 0).sum() >= 2:
+                charges = range(y.size(-1))
+                fig, ax = plt.subplots()
+                ax.bar(charges, y.numpy(), color="blue")
+                ax.bar(charges, -p.numpy(), color="orange")
+                ax.set_xlabel("Charge")
+                ax.set_ylabel("Abundance")
+                ax.set_title("Observed (top) vs Predicted (bottom)")
+                self.logger.experiment.log({"mirror_plot": wandb.Image(fig)}, commit=False)
+                plt.close(fig)
+                break
+        self.val_examples = []
+
+    def configure_optimizers(self):
+        return torch.optim.Adam(self.parameters(), lr=self.hparams.lr)

--- a/src/lodestone/train.py
+++ b/src/lodestone/train.py
@@ -1,0 +1,47 @@
+import json
+import os
+from argparse import ArgumentParser
+
+import pytorch_lightning as pl
+from pytorch_lightning.loggers import WandbLogger
+
+from .data import PeptideDataModule
+from .model import LodestoneLightningModule
+
+
+def parse_args():
+    parser = ArgumentParser()
+    parser.add_argument("--config", type=str, default="config.json")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    with open(args.config) as f:
+        cfg = json.load(f)
+
+    os.environ.setdefault("WANDB_MODE", "offline")
+    logger = WandbLogger(project="lodestone", log_model=False)
+
+    datamodule = PeptideDataModule(cfg["csv_path"], batch_size=cfg.get("batch_size", 32))
+    datamodule.setup("fit")
+
+    model = LodestoneLightningModule(
+        num_runs=len(datamodule.run_mapping),
+        lr=cfg.get("lr", 1e-3),
+        d_model=cfg.get("d_model", 128),
+        nhead=cfg.get("nhead", 4),
+        num_layers=cfg.get("num_layers", 2),
+        run_dim=cfg.get("run_dim", 32),
+    )
+
+    trainer_args = {"max_epochs": cfg.get("max_epochs", 10), "logger": logger}
+    for key in ["limit_train_batches", "limit_val_batches", "fast_dev_run"]:
+        if key in cfg:
+            trainer_args[key] = cfg[key]
+    trainer = pl.Trainer(**trainer_args)
+    trainer.fit(model, datamodule=datamodule)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement Lodestone transformer model and Lightning module for peptide charge state prediction with per-run parameters and k-factor decoder
- add data module, training entrypoint, and configuration
- provide Docker devcontainer, requirements, and SLURM training script

## Testing
- `pytest`
- `PYTHONPATH=src python -m lodestone.train --config config_test.json`


------
https://chatgpt.com/codex/tasks/task_e_68b082ff1088832583bd37324ba2779a