### PR TITLE
Add gradient clipping to training pipeline

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,5 +7,6 @@
   "nhead": 4,
   "num_layers": 4,
   "run_dim": 4,
-  "max_epochs": 100
+  "max_epochs": 100,
+  "gradient_clip_val": 1.0
 }

--- a/src/lodestone/train.py
+++ b/src/lodestone/train.py
@@ -40,7 +40,11 @@ def main():
         run_dim=cfg.get("run_dim", 32),
     )
 
-    trainer_args = {"max_epochs": cfg.get("max_epochs", 10), "logger": logger}
+    trainer_args = {
+        "max_epochs": cfg.get("max_epochs", 10),
+        "logger": logger,
+        "gradient_clip_val": cfg.get("gradient_clip_val", 1.0),
+    }
     for key in ["limit_train_batches", "limit_val_batches", "fast_dev_run"]:
         if key in cfg:
             trainer_args[key] = cfg[key]


### PR DESCRIPTION
## Summary
- allow configuring gradient clipping in training via `gradient_clip_val`
- document new setting in default `config.json`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b10f10dea88325ac66e717039a015b