### PR TITLE
Add symmetric cross-entropy loss

### DIFF
--- a/src/lodestone/__init__.py
+++ b/src/lodestone/__init__.py
@@ -1,3 +1,3 @@
 """Lodestone package."""
 
-__all__ = ["data", "model", "train", "concat_csd"]
+__all__ = ["data", "model", "train", "concat_csd", "losses"]

--- a/src/lodestone/losses.py
+++ b/src/lodestone/losses.py
@@ -1,0 +1,45 @@
+import torch
+import torch.nn.functional as F
+
+
+def symmetric_cross_entropy(
+    preds: torch.Tensor,
+    target: torch.Tensor,
+    alpha: float = 1.0,
+    beta: float = 1.0,
+    epsilon: float = 1e-7,
+) -> torch.Tensor:
+    """Compute the symmetric cross-entropy between ``preds`` and ``target``.
+
+    ``preds`` are raw, unnormalized logits while ``target`` is a probability
+    distribution over the same classes.  The loss is a weighted sum of the
+    forward cross entropy (``CE(target, preds)``) and the reverse cross entropy
+    (``CE(preds, target)``).
+
+    Parameters
+    ----------
+    preds:
+        Unnormalized model predictions of shape ``[*, C]``.
+    target:
+        Ground-truth probability distribution of the same shape.
+    alpha:
+        Weight for the standard cross entropy term.
+    beta:
+        Weight for the reverse cross entropy term.
+    epsilon:
+        Small constant for numerical stability when taking ``log`` of
+        ``target``.
+
+    Returns
+    -------
+    torch.Tensor
+        Element-wise symmetric cross-entropy loss with the same shape as
+        ``target``.
+    """
+
+    log_probs = F.log_softmax(preds, dim=-1)
+    probs = log_probs.exp()
+
+    ce = -(target * log_probs)
+    rce = -(probs * torch.log(target.clamp_min(epsilon)))
+    return alpha * ce + beta * rce

--- a/src/lodestone/model.py
+++ b/src/lodestone/model.py
@@ -6,6 +6,7 @@ import torch.nn.functional as F
 import pytorch_lightning as pl
 
 from .data import VOCAB
+from .losses import symmetric_cross_entropy
 
 
 class PositionalEncoding(nn.Module):
@@ -117,8 +118,8 @@ class LodestoneLightningModule(pl.LightningModule):
     ):
         x, y, run_ids, mask, _ = batch
         preds_bias, preds_full = self(x, run_ids, return_bias=True)
-        bias_loss_all = -(y * F.log_softmax(preds_bias, dim=-1))
-        full_loss_all = -(y * F.log_softmax(preds_full, dim=-1))
+        bias_loss_all = symmetric_cross_entropy(preds_bias, y)
+        full_loss_all = symmetric_cross_entropy(preds_full, y)
         mask = mask.float()
         bias_loss = (bias_loss_all * mask).sum() / mask.sum()
         full_loss = (full_loss_all * mask).sum() / mask.sum()
@@ -137,8 +138,8 @@ class LodestoneLightningModule(pl.LightningModule):
     ):
         x, y, run_ids, mask, seqs = batch
         preds_bias, preds_full = self(x, run_ids, return_bias=True)
-        bias_loss_all = -(y * F.log_softmax(preds_bias, dim=-1))
-        full_loss_all = -(y * F.log_softmax(preds_full, dim=-1))
+        bias_loss_all = symmetric_cross_entropy(preds_bias, y)
+        full_loss_all = symmetric_cross_entropy(preds_full, y)
         mask = mask.float()
         bias_loss = (bias_loss_all * mask).sum() / mask.sum()
         full_loss = (full_loss_all * mask).sum() / mask.sum()

--- a/tests/test_symmetric_cross_entropy.py
+++ b/tests/test_symmetric_cross_entropy.py
@@ -1,0 +1,22 @@
+import torch
+from lodestone.losses import symmetric_cross_entropy
+
+
+def test_symmetric_cross_entropy_matches_manual():
+    preds = torch.log(torch.tensor([0.7, 0.3]))
+    target = torch.tensor([0.6, 0.4])
+    loss = symmetric_cross_entropy(preds, target)
+
+    manual = -(
+        target * torch.log(torch.tensor([0.7, 0.3]))
+        + torch.tensor([0.7, 0.3]) * torch.log(target)
+    )
+    assert torch.allclose(loss, manual)
+
+
+def test_symmetric_cross_entropy_is_symmetric():
+    p = torch.tensor([0.7, 0.3])
+    q = torch.tensor([0.6, 0.4])
+    loss_pq = symmetric_cross_entropy(torch.log(p), q).sum()
+    loss_qp = symmetric_cross_entropy(torch.log(q), p).sum()
+    assert torch.allclose(loss_pq, loss_qp)


### PR DESCRIPTION
## Summary
- implement symmetric cross-entropy combining forward and reverse terms
- use symmetric cross-entropy for training and validation
- test symmetric cross-entropy correctness and symmetry

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b11a88d43c8325a4f23ccf5fdfdb49