### PR TITLE
Handle padding in peptide encoding

### DIFF
--- a/src/lodestone/data.py
+++ b/src/lodestone/data.py
@@ -111,8 +111,11 @@ except Exception:  # pragma: no cover
 
 AMINO_ACIDS = list("ACDEFGHIKLMNPQRSTVWY")
 SPECIAL_TOKENS = ["camC", "oxM", "ac-", "nemC"]
-VOCAB = AMINO_ACIDS + SPECIAL_TOKENS
-TOKEN_TO_IDX: Dict[str, int] = {tok: i for i, tok in enumerate(VOCAB)}
+PAD_TOKEN = "<PAD>"
+PAD_IDX = 0
+VOCAB = [PAD_TOKEN] + AMINO_ACIDS + SPECIAL_TOKENS
+TOKEN_TO_IDX: Dict[str, int] = {PAD_TOKEN: PAD_IDX}
+TOKEN_TO_IDX.update({tok: i + 1 for i, tok in enumerate(AMINO_ACIDS + SPECIAL_TOKENS)})
 
 # Monoisotopic masses of amino acids and special tokens (in Daltons)
 AA_MASS: Dict[str, float] = {
@@ -207,6 +210,7 @@ def tokenize_sequence(seq: str) -> List[int]:
 
 def one_hot(indices: List[int]) -> torch.Tensor:
     eye = torch.eye(len(VOCAB))
+    eye[PAD_IDX] = 0
     return eye[indices]
 
 
@@ -304,7 +308,7 @@ class PeptideDataModule(pl.LightningDataModule):
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, List[str]]:
         seqs = [tokenize_sequence(rec.sequence) for rec in batch]
         max_len = max(len(s) for s in seqs)
-        padded = [s + [0] * (max_len - len(s)) for s in seqs]
+        padded = [s + [PAD_IDX] * (max_len - len(s)) for s in seqs]
         one_hot_seqs = torch.stack([one_hot(s) for s in padded])
         charges = torch.stack([rec.charges for rec in batch])
         run_ids_list = [rec.run_id for rec in batch]

--- a/src/lodestone/model.py
+++ b/src/lodestone/model.py
@@ -66,10 +66,13 @@ class LodestoneModel(nn.Module):
         self, x: torch.Tensor, run_ids: torch.Tensor, return_bias: bool = False
     ) -> Tuple[torch.Tensor, torch.Tensor] | torch.Tensor:
         # x: [B, L, V]
+        valid_mask = x.sum(dim=-1) > 0
         x = self.embed(x)
         x = self.pos_encoder(x)
-        x = self.transformer(x)
-        x = x.mean(dim=1)
+        x = self.transformer(x, src_key_padding_mask=~valid_mask)
+        mask = valid_mask.unsqueeze(-1).type_as(x)
+        lengths = valid_mask.sum(dim=1).clamp(min=1).unsqueeze(-1)
+        x = (x * mask).sum(dim=1) / lengths
         feats = self.feature_head(x)
         params_bias = self.bias_head(feats)
         k_weights = self.k_factor_head(run_ids).view(run_ids.size(0), 3, feats.size(1))

--- a/tests/test_padding.py
+++ b/tests/test_padding.py
@@ -1,0 +1,28 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from lodestone.data import one_hot, PAD_IDX, TOKEN_TO_IDX, VOCAB
+from lodestone.model import LodestoneModel
+
+
+def test_model_padding_invariance():
+    seq = [TOKEN_TO_IDX["A"], TOKEN_TO_IDX["C"], TOKEN_TO_IDX["D"]]
+    padded_seq = seq + [PAD_IDX, PAD_IDX]
+
+    x_unpadded = one_hot(seq).unsqueeze(0)
+    x_padded = one_hot(padded_seq).unsqueeze(0)
+
+    model = LodestoneModel(d_model=16, nhead=4, num_layers=1, run_dim=8, num_runs=1)
+
+    run_ids = torch.zeros(1, dtype=torch.long)
+
+    logits_bias_unpadded, _ = model(x_unpadded, run_ids, return_bias=True)
+    logits_bias_padded, _ = model(x_padded, run_ids, return_bias=True)
+
+    torch.testing.assert_close(logits_bias_unpadded, logits_bias_padded)
+
+
+def test_vocab_size_matches_embedding():
+    model = LodestoneModel(d_model=8, nhead=1, num_layers=1, run_dim=4, num_runs=1)
+    assert model.embed.in_features == len(VOCAB)


### PR DESCRIPTION
## Summary
- add an explicit PAD token/index and ensure tokenization and batching use it when sequences are padded
- zero out PAD embeddings so padded positions do not contribute signal and mask them inside the transformer pooling
- add smoke tests checking padding invariance of the bias-only logits and the embedding input size

## Testing
- pytest *(fails: missing optional dependencies pandas/torch in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d898cb4d1883259f208835a86ca612