### PR TITLE
Add pad token handling and mask padded transformer inputs

### DIFF
--- a/src/lodestone/data.py
+++ b/src/lodestone/data.py
@@ -111,7 +111,9 @@ except Exception:  # pragma: no cover
 
 AMINO_ACIDS = list("ACDEFGHIKLMNPQRSTVWY")
 SPECIAL_TOKENS = ["camC", "oxM", "ac-", "nemC"]
-VOCAB = AMINO_ACIDS + SPECIAL_TOKENS
+PAD_TOKEN = "<pad>"
+PAD_IDX = 0
+VOCAB = [PAD_TOKEN] + AMINO_ACIDS + SPECIAL_TOKENS
 TOKEN_TO_IDX: Dict[str, int] = {tok: i for i, tok in enumerate(VOCAB)}
 
 # Monoisotopic masses of amino acids and special tokens (in Daltons)
@@ -207,7 +209,12 @@ def tokenize_sequence(seq: str) -> List[int]:
 
 def one_hot(indices: List[int]) -> torch.Tensor:
     eye = torch.eye(len(VOCAB))
-    return eye[indices]
+    encoded = eye[indices]
+    if indices:
+        mask_values = [0.0 if idx == PAD_IDX else 1.0 for idx in indices]
+        mask = torch.tensor(mask_values, dtype=encoded.dtype).unsqueeze(-1)
+        encoded = encoded * mask
+    return encoded
 
 
 @dataclass
@@ -304,7 +311,7 @@ class PeptideDataModule(pl.LightningDataModule):
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, List[str]]:
         seqs = [tokenize_sequence(rec.sequence) for rec in batch]
         max_len = max(len(s) for s in seqs)
-        padded = [s + [0] * (max_len - len(s)) for s in seqs]
+        padded = [s + [PAD_IDX] * (max_len - len(s)) for s in seqs]
         one_hot_seqs = torch.stack([one_hot(s) for s in padded])
         charges = torch.stack([rec.charges for rec in batch])
         run_ids_list = [rec.run_id for rec in batch]

--- a/src/lodestone/model.py
+++ b/src/lodestone/model.py
@@ -67,10 +67,13 @@ class LodestoneModel(nn.Module):
         self, x: torch.Tensor, run_ids: torch.Tensor, return_bias: bool = False
     ) -> Tuple[torch.Tensor, torch.Tensor] | torch.Tensor:
         # x: [B, L, V]
+        padding_mask = (x.abs().sum(dim=-1) == 0)
         x = self.embed(x)
         x = self.pos_encoder(x)
-        x = self.transformer(x)
-        x = x.mean(dim=1)
+        x = self.transformer(x, src_key_padding_mask=padding_mask)
+        non_pad = (~padding_mask).unsqueeze(-1).to(x.dtype)
+        lengths = non_pad.sum(dim=1).clamp(min=1.0)
+        x = (x * non_pad).sum(dim=1) / lengths
         feats = self.feature_head(x)
         params_bias = self.bias_head(feats)
         k_weights = self.k_factor_head(run_ids).view(run_ids.size(0), 3, feats.size(1))

--- a/tests/test_padding.py
+++ b/tests/test_padding.py
@@ -1,0 +1,36 @@
+try:
+    import torch
+except Exception:  # pragma: no cover - fallback when torch unavailable
+    from lodestone.data import torch
+
+from lodestone.data import one_hot, PAD_IDX, TOKEN_TO_IDX
+from lodestone.model import LodestoneModel
+
+
+def _model_for_test() -> LodestoneModel:
+    # Small model for test purposes; use deterministic evaluation mode.
+    model = LodestoneModel(
+        d_model=16,
+        nhead=4,
+        num_layers=1,
+        run_dim=8,
+        num_runs=1,
+    )
+    model.eval()
+    return model
+
+
+def test_padded_and_unpadded_bias_logits_match():
+    model = _model_for_test()
+    run_ids = torch.tensor([0])
+
+    seq_tokens = [TOKEN_TO_IDX["A"], TOKEN_TO_IDX["C"]]
+    unpadded = one_hot(seq_tokens).unsqueeze(0)
+
+    padded_tokens = seq_tokens + [PAD_IDX, PAD_IDX]
+    padded = one_hot(padded_tokens).unsqueeze(0)
+
+    logits_unpadded, _ = model(unpadded, run_ids, return_bias=True)
+    logits_padded, _ = model(padded, run_ids, return_bias=True)
+
+    assert torch.allclose(logits_unpadded, logits_padded, atol=1e-6)

--- a/tests/test_split_normal.py
+++ b/tests/test_split_normal.py
@@ -1,4 +1,7 @@
-import torch
+try:
+    import torch
+except Exception:  # pragma: no cover - fallback when torch unavailable
+    from lodestone.data import torch
 
 from lodestone.model import LodestoneModel
 


### PR DESCRIPTION
## Summary
- introduce an explicit padding token for the peptide vocabulary and ensure one-hot encodings remain zero for pad positions
- update the transformer encoder to mask padded tokens during attention and pooling so padding does not affect sequence features
- add a regression test covering padded vs. unpadded bias logits and allow existing tests to run without a hard torch dependency

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d89dafb8fc83259b2241bfb5ddd8bb